### PR TITLE
Refactor MonkeyFragmentManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk: oraclejdk8
+sudo: true
 
 android:
   components:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.criptext.uisample">
 
     <uses-permission android:name="android.permission.VIBRATE"/>
@@ -8,11 +9,13 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!-- TODO remove the tools replace line -->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        tools:replace="android:theme"
         android:theme="@style/AppTheme">
         <activity android:name=".MainFragmentActivity">
             <intent-filter>

--- a/app/src/main/java/com/criptext/uisample/conversation/StateFragment.java
+++ b/app/src/main/java/com/criptext/uisample/conversation/StateFragment.java
@@ -1,0 +1,34 @@
+package com.criptext.uisample.conversation;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+
+import com.criptext.monkeykitui.conversation.ConversationsList;
+import com.criptext.monkeykitui.conversation.MonkeyConversation;
+import com.criptext.monkeykitui.util.MonkeyFragmentManager;
+
+import java.util.Stack;
+
+/**
+ * Created by gesuwall on 12/21/16.
+ */
+public class StateFragment extends Fragment {
+    public Stack<MonkeyFragmentManager.FragmentTypes> mkFragmentStack;
+    public ConversationsList conversationsList;
+    public MonkeyConversation activeConversation;
+
+    public static StateFragment newStateFragment (Context ctx) {
+        StateFragment fragment = new StateFragment();
+        fragment.mkFragmentStack = new Stack<>();
+        fragment.conversationsList = new ConversationsList(new FakeConversations().getAll(ctx));
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+}

--- a/monkeykitui/build.gradle
+++ b/monkeykitui/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testCompile 'org.robolectric:robolectric:3.1.1'
+    testCompile 'org.robolectric:shadows-support-v4:3.0'
+    testCompile 'org.amshove.kluent:kluent:1.11'
     //robolectric needs this for API 23 https://github.com/robolectric/robolectric/issues/1932
     testCompile 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
 

--- a/monkeykitui/src/main/AndroidManifest.xml
+++ b/monkeykitui/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.criptext.monkeykitui">
 
+    <!-- The AppCompat theme is needed for robolectric tests -->
     <application
         android:allowBackup="true"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+        >
 
     </application>
 

--- a/monkeykitui/src/main/kotlin/com/criptext/monkeykitui/toolbar/MonkeyToolbar.kt
+++ b/monkeykitui/src/main/kotlin/com/criptext/monkeykitui/toolbar/MonkeyToolbar.kt
@@ -25,98 +25,53 @@ import de.hdodenhof.circleimageview.CircleImageView
  * Created by daniel on 9/16/16.
  */
 
-open class MonkeyToolbar(var activity: AppCompatActivity, var conversationsTitle: String, var expandColor: Int) : AppBarLayout.OnOffsetChangedListener{
+open class MonkeyToolbar(activity: AppCompatActivity) {
 
-    var imageViewAvatar: CircleImageView?
-    var toolbar: Toolbar
-    var monkeyId: String?
-    var avatarURL: String?
-    var customToolbar : HeaderView?
+    val toolbar: Toolbar
+    val customToolbar : HeaderView
+    val actionBar : ActionBar
+    val appBarLayout : AppBarLayout
 
     init {
-
-        monkeyId = null
-        avatarURL = null
         toolbar = activity.findViewById(R.id.toolbar) as Toolbar
-        val appToolbar = activity.findViewById(R.id.toolbar_layout) as AppBarLayout?
-
-        val mInflater = LayoutInflater.from(activity)
-        //val mCustomView = mInflater.inflate(R.layout.custom_toolbar, toolbar)
-
         customToolbar = activity.findViewById(R.id.custom_toolbar) as HeaderView
-        imageViewAvatar = customToolbar?.findViewById(R.id.imageViewAvatar) as CircleImageView
 
         activity.setSupportActionBar(toolbar)
-        activity.supportActionBar?.setDisplayShowTitleEnabled(false)
-        activity.supportActionBar?.setDisplayHomeAsUpEnabled(false)
-
-        checkIfChatFragmentIsVisible()
-
-        setupClickListener()
+        actionBar = activity.supportActionBar!!
+        actionBar.setDisplayShowTitleEnabled(false)
+        actionBar.setDisplayHomeAsUpEnabled(false)
+        appBarLayout = activity.findViewById(R.id.toolbar_layout) as AppBarLayout
     }
 
-    fun checkIfChatFragmentIsVisible(){
-        if (activity.supportFragmentManager.backStackEntryCount > 0) {
-            activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
-            val monkeyChatFragment = activity.supportFragmentManager.findFragmentByTag(MonkeyFragmentManager.CHAT_FRAGMENT_TAG) as MonkeyChatFragment?
-            customToolbar?.title?.text = (EmojiHandler.decodeJava(EmojiHandler.decodeJava(monkeyChatFragment?.getChatTitle())))
-            customToolbar?.imageView?.visibility = View.VISIBLE
+    fun setConversationsToolbar(title: String) {
+        customToolbar.title.text = title
+        customToolbar.imageView.visibility = View.GONE
+        customToolbar.subtitle.visibility = View.GONE
 
-            activity.supportFragmentManager.getBackStackEntryAt(activity.supportFragmentManager.backStackEntryCount - 1)
+        appBarLayout.setExpanded(false)
+        appBarLayout.isActivated = false
+        actionBar.setDisplayHomeAsUpEnabled(false)
+    }
 
-            Utils.setAvatarAsync(activity, imageViewAvatar as ImageView, monkeyChatFragment?.getAvatarURL(), !(monkeyChatFragment?.isGroupConversation() ?: false), null)
-        } else {
-            customToolbar?.title?.text = "Monkey Sample"
-            customToolbar?.imageView?.visibility = View.GONE
-            customToolbar?.subtitle?.visibility = View.GONE
-
-            lockAppBarClosed()
-
-            activity.supportActionBar?.setDisplayHomeAsUpEnabled(false)
-
+    fun setChatToolbar(chatTitle: String, avatarURL: String?, isGroup: Boolean) {
+        customToolbar.title.text = EmojiHandler.decodeJava(EmojiHandler.decodeJava(chatTitle))
+        customToolbar.imageView.visibility = View.VISIBLE
+        if (avatarURL != null)
+                Utils.setAvatarAsync(toolbar.context, customToolbar.imageView, avatarURL,
+                        isGroup, null)
+        else {
+            val imgRes = if (isGroup) R.drawable.mk_default_group_avatar
+                        else R.drawable.mk_default_user_img
+            customToolbar.imageView.setImageResource(imgRes)
         }
     }
 
-    fun setupClickListener(){
-        customToolbar?.secondContainer?.setOnClickListener(View.OnClickListener {
-            if (activity.supportFragmentManager.backStackEntryCount > 0) {
-                val toolbar_layout = activity.findViewById(R.id.toolbar_layout) as AppBarLayout
-                unlockAppBarOpen()
-                (activity as ToolbarDelegate).onClickToolbar(monkeyId?:"",
-                        "", "", "")
-            }
-        })
-    }
-
-    fun configureForChat(chatTitle: String, avatarURL: String, isGroup: Boolean, monkeyID: String){
-        //Utils.setAvatarAsync(activity, imageViewAvatar as ImageView, avatarURL, !isGroup, null)
-
-        this.avatarURL = avatarURL
-        this.monkeyId = monkeyID
+    fun setOnClickListener(listener: View.OnClickListener){
+        customToolbar.secondContainer.setOnClickListener(listener)
     }
 
     fun setSubtitle(subtitle: String){
-        customToolbar?.subtitle?.visibility = View.VISIBLE
-        customToolbar?.subtitle?.text = EmojiHandler.decodeJava(EmojiHandler.decodeJava(subtitle))
-
+        customToolbar.subtitle.visibility = View.VISIBLE
+        customToolbar.subtitle.text = EmojiHandler.decodeJava(EmojiHandler.decodeJava(subtitle))
     }
-
-    override fun onOffsetChanged(appBarLayout: AppBarLayout?, verticalOffset: Int) {
-        throw UnsupportedOperationException("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    fun lockAppBarClosed() {
-        val appToolbar = activity.findViewById(R.id.toolbar_layout) as AppBarLayout?
-        appToolbar?.setExpanded(false)
-        appToolbar?.setActivated(false)
-        //appToolbar?.getLayoutParams()?.height = activity.resources.getDimension(R.dimen.mt_toolbar_height).toInt()
-    }
-
-    fun unlockAppBarOpen() {
-        val appToolbar = activity.findViewById(R.id.toolbar_layout) as AppBarLayout?
-        appToolbar?.setExpanded(true)
-        appToolbar?.setActivated(true)
-        //appToolbar?.getLayoutParams()?.height = activity.resources.getDimension(R.dimen.mk_appbar_height).toInt()
-    }
-
 }

--- a/monkeykitui/src/test/java/com/criptext/monkeykitui/TestActivity.kt
+++ b/monkeykitui/src/test/java/com/criptext/monkeykitui/TestActivity.kt
@@ -1,0 +1,65 @@
+package com.criptext.monkeykitui
+
+import android.support.v7.app.AppCompatActivity
+import com.criptext.monkeykitui.conversation.ConversationsActivity
+import com.criptext.monkeykitui.conversation.ConversationsList
+import com.criptext.monkeykitui.conversation.MonkeyConversation
+import com.criptext.monkeykitui.recycler.ChatActivity
+import com.criptext.monkeykitui.recycler.GroupChat
+import com.criptext.monkeykitui.recycler.MonkeyItem
+
+/**
+ * Created by gesuwall on 12/21/16.
+ */
+
+class TestActivity: AppCompatActivity(), ConversationsActivity, ChatActivity {
+    override fun onConversationDeleted(group: MonkeyConversation) {
+    }
+
+    override fun onLoadMoreConversations(loadedConversations: Int) {
+    }
+
+    override fun setConversationsFragment(conversationsFragment: MonkeyConversationsFragment?) {
+    }
+
+    override fun onRequestConversations() = ConversationsList()
+
+    override fun deleteChatFragment(monkeyChatFragment: MonkeyChatFragment) {
+    }
+
+    override fun deleteAllMessages(conversationId: String) {
+    }
+
+    override fun getGroupChat(conversationId: String, membersIds: String) = null
+    override fun getInitialMessages(conversationId: String): List<MonkeyItem>? = null
+
+    override fun isOnline(): Boolean = true
+
+    override fun onFileDownloadRequested(item: MonkeyItem) {
+    }
+
+    override fun onFileUploadRequested(item: MonkeyItem) {
+    }
+
+    override fun onLoadMoreMessages(conversationId: String, currentMessageCount: Int) {
+    }
+
+    override fun onMessageRemoved(item: MonkeyItem, unsent: Boolean) {
+    }
+
+    override fun onStartChatFragment(conversationId: String) {
+    }
+
+    override fun onStopChatFragment(conversationId: String) {
+    }
+
+    override fun retainMessages(conversationId: String, messages: List<MonkeyItem>) {
+    }
+
+    override fun setChatFragment(chatFragment: MonkeyChatFragment?) {
+    }
+
+    override fun onConversationClicked(conversation: MonkeyConversation) {
+    }
+
+}

--- a/monkeykitui/src/test/kotlin/com/criptext/monkeykitui/Chat Fragment Tests.kt
+++ b/monkeykitui/src/test/kotlin/com/criptext/monkeykitui/Chat Fragment Tests.kt
@@ -1,0 +1,41 @@
+package com.criptext.monkeykitui
+
+import org.amshove.kluent.`should equal`
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Created by gesuwall on 12/20/16.
+ */
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class)
+class `Chat Fragment Tests` {
+
+    @Test
+    fun `Builder object should add all variables to the fragments arguments bundle`() {
+        val chatId = "123456789"
+        val chatName = "My Test Chat"
+        val avatarURL = "/monkeykitphotos/user/123456789"
+        val lastRead = 1000000000L
+        val layoutId = 100
+        val fragment = MonkeyChatFragment.Builder(chatId, chatName)
+                        .setAvatarURL(avatarURL)
+                        .setLastRead(lastRead)
+                        .setReachedEnd(true)
+                        .setLayoutId(layoutId)
+                        .build()
+
+        val args = fragment.arguments
+        args.getString(MonkeyChatFragment.chatConversationId) `should equal` chatId
+        args.getString(MonkeyChatFragment.chatTitleName) `should equal` chatName
+        args.getString(MonkeyChatFragment.chatAvatarUrl) `should equal` avatarURL
+        args.getLong(MonkeyChatFragment.initalLastReadValue) `should equal` lastRead
+        args.getInt(MonkeyChatFragment.chatLayoutId) `should equal` layoutId
+        args.getBoolean(MonkeyChatFragment.chatHasReachedEnd) `should equal` true
+
+
+    }
+}

--- a/monkeykitui/src/test/kotlin/com/criptext/monkeykitui/util/MonkeyFragmentManager Test.kt
+++ b/monkeykitui/src/test/kotlin/com/criptext/monkeykitui/util/MonkeyFragmentManager Test.kt
@@ -1,0 +1,95 @@
+package com.criptext.monkeykitui.util
+
+import android.view.View
+import com.criptext.monkeykitui.BuildConfig
+import com.criptext.monkeykitui.MonkeyChatFragment
+import com.criptext.monkeykitui.TestActivity
+import org.amshove.kluent.`should equal`
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.*
+
+/**
+ * Created by gesuwall on 12/21/16.
+ */
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class)
+class `MonkeyFragmentManager Test` {
+
+    @Test
+    fun `Should transition from a conversations fragment to a chat fragment`() {
+        var controller = Robolectric.buildActivity(TestActivity::class.java)
+                .create().start().visible()
+        var act = controller.get()
+        val activityTitle = "Test Activity"
+        val mkFragmentStack = Stack<MonkeyFragmentManager.FragmentTypes>()
+        val mfm = MonkeyFragmentManager(act, activityTitle, mkFragmentStack)
+
+        //set the conversations fragment
+        mfm.setContentLayout(null)
+
+        //init toolbar variables before asserting
+        val monkeyToolbar = mfm.monkeyToolbar!!
+        val customToolbar = monkeyToolbar.customToolbar
+        val appBarLayout = monkeyToolbar.appBarLayout
+
+        customToolbar.title.text.toString() `should equal` activityTitle
+        customToolbar.imageView.visibility `should equal` View.GONE
+        customToolbar.subtitle.visibility `should equal` View.GONE
+        appBarLayout.isActivated `should equal` false
+
+
+        //Now set the chats fragment
+        val contactName = "John Smith"
+        val chatFragment = MonkeyChatFragment.Builder("0", contactName)
+            .setLastRead(System.currentTimeMillis())
+            .setReachedEnd(false)
+            .build();
+
+        mfm.setChatFragment(chatFragment)
+        customToolbar.title.text `should equal` contactName
+        customToolbar.imageView.visibility `should equal` View.VISIBLE
+
+    }
+
+    @Test
+    fun `MonkeyFragmentManager can set a click listener to the toolbar`() {
+         var controller = Robolectric.buildActivity(TestActivity::class.java)
+                .create().start().visible()
+        var act = controller.get()
+        val activityTitle = "Test Activity"
+        val mkFragmentStack = Stack<MonkeyFragmentManager.FragmentTypes>()
+        val mfm = MonkeyFragmentManager(act, activityTitle, mkFragmentStack)
+
+        //set the layout with toolbar
+        mfm.setContentLayout(null)
+
+        //init toolbar variables before asserting
+        val monkeyToolbar = mfm.monkeyToolbar!!
+        val customToolbar = monkeyToolbar.customToolbar
+
+        var clicks = 0
+        mfm.setToolbarOnClickListener(View.OnClickListener {
+            clicks++
+        })
+
+        clicks `should equal` 0
+
+        customToolbar.secondContainer.callOnClick()
+        clicks `should equal` 1
+
+        customToolbar.secondContainer.callOnClick()
+        clicks `should equal` 2
+
+        customToolbar.secondContainer.callOnClick()
+        customToolbar.secondContainer.callOnClick()
+        customToolbar.secondContainer.callOnClick()
+        clicks `should equal` 5
+    }
+
+
+}


### PR DESCRIPTION
MonkeyFragmentManager has been modified to be easier to use.
MonkeyToolbar now deals only with the views of the toolbar.
MonkeyFragmentManager uses a stack to keep track of the fragments and
compares that to supportFragmentManager's backStack when the backstack
changes.

user must now call restoreToolbar() to draw the appropiate toolbar when
the activity is being restored.

MonkyChatFragment now has a Builder constructor for easier use.

UI Sample must now keep state in a headless fragment